### PR TITLE
Update to Latin-1 encoding in Radio error handler

### DIFF
--- a/src/main/java/me/alexdevs/classicPeripherals/peripherals/AbstractRadioPeripheral.java
+++ b/src/main/java/me/alexdevs/classicPeripherals/peripherals/AbstractRadioPeripheral.java
@@ -64,7 +64,7 @@ public abstract class AbstractRadioPeripheral implements IPeripheral {
     }
 
     public String flipString(String data, double percentage) {
-        var bytes = data.getBytes(StandardCharsets.US_ASCII);
+        var bytes = data.getBytes(StandardCharsets.ISO_8859_1);
         var total = bytes.length * 8;
         var toFlip = (int) Math.ceil(total * percentage);
 
@@ -74,7 +74,7 @@ public abstract class AbstractRadioPeripheral implements IPeripheral {
             var bitIndex = bit % 8;
             bytes[byteIndex] ^= (byte) (1 << bitIndex);
         }
-        return new String(bytes, StandardCharsets.US_ASCII);
+        return new String(bytes, StandardCharsets.ISO_8859_1);
     }
 
     public void receive(String data, double distance, double range) {


### PR DESCRIPTION
Previously the Radio Tower error handler used US_ASCII encoding internally, resulting in bytes mistakenly only corrupting to values between 1-127. ISO-8859-1 (Latin-1) covers extended ASCII which correctly maps to the set of byte values supported by ComputerCraft.